### PR TITLE
Middleware update

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,6 @@
 ### Build and Unit Test the App
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+
 RUN mkdir -p /src/app && \
     mkdir -p /src/unit-tests
 
@@ -30,6 +31,7 @@ RUN dotnet publish -c Release -o /app
 
 ### Build the runtime container
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
+
 EXPOSE 4120
 WORKDIR /app
 

--- a/src/Dockerfile-Dev
+++ b/src/Dockerfile-Dev
@@ -4,6 +4,14 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 RUN mkdir -p /src && \
     mkdir -p /root/.azure
 
+### Optional: Set Proxy Variables
+# ENV http_proxy {value}
+# ENV https_proxy {value}
+# ENV HTTP_PROXY {value}
+# ENV HTTPS_PROXY {value}
+# ENV no_proxy {value}
+# ENV NO_PROXY {value}
+
 ### copy the source and unit tests
 COPY . /src
 
@@ -12,10 +20,10 @@ WORKDIR /src/app
 
 ### install azure cli
 RUN dotnet restore && \
-apt-get update && \
-apt-get install -y apt-transport-https ca-certificates curl software-properties-common libssl-dev git wget nano lsb-release jq && \
-curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
-CLI_REPO=$(lsb_release -cs) && \
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${CLI_REPO} main" > /etc/apt/sources.list.d/azure-cli.list && \
-apt-get update && \
-apt-get install -y azure-cli
+    apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates curl software-properties-common libssl-dev git wget nano lsb-release jq && \
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
+    CLI_REPO=$(lsb_release -cs) && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${CLI_REPO} main" > /etc/apt/sources.list.d/azure-cli.list && \
+    apt-get update && \
+    apt-get install -y azure-cli

--- a/src/Middleware/robotsText.cs
+++ b/src/Middleware/robotsText.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Builder;
 
-namespace Helium
+namespace fourCo.Middleware
 {
     public static class RobotsMiddlewareExtensions
     {
+        // response that prevents all indexing
+        static readonly byte[] responseBytes = System.Text.Encoding.UTF8.GetBytes("# Prevent indexing\r\nUser-agent: *\r\nDisallow: /\r\n");
+        
         /// <summary>
         /// Middleware extension method to handle /robots*.txt request
         /// App Service sends a warmup request of /robots8327.txt (where 8327 is a random number)
@@ -22,14 +25,11 @@ namespace Helium
 
                 // matches /robots*.txt (/robots.txt /robots123.txt etc)
                 // does not match /robots/robots.txt
-                if (path.StartsWith("robots") && path.EndsWith(".txt") && !path.Contains("/"))
+                if (! path.Contains("/") && path.StartsWith("robots") && path.EndsWith(".txt"))
                 {
-                    // convert content to byte array
-                    byte[] b = System.Text.Encoding.UTF8.GetBytes("User-agent: *\r\nDisallow: /\r\n");
-
                     // return the content
                     context.Response.ContentType = "text/plain";
-                    await context.Response.Body.WriteAsync(b, 0, b.Length);
+                    await context.Response.Body.WriteAsync(responseBytes, 0, responseBytes.Length);
                 }
                 else
                 {

--- a/src/Middleware/robotsText.cs
+++ b/src/Middleware/robotsText.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 
-namespace fourCo.Middleware
+namespace Helium
 {
     public static class RobotsMiddlewareExtensions
     {

--- a/src/app/helium.csproj
+++ b/src/app/helium.csproj
@@ -18,6 +18,10 @@
   </PropertyGroup> 
 
   <ItemGroup>
+    <Compile Include="..\Middleware\robotsText.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" /> 
     <PackageReference Include="Microsoft.AspNetCore.All" /> 
     <PackageReference Include="microsoft.azure.documentdb.core" Version="2.5.1" /> 

--- a/src/integration-test/Dockerfile
+++ b/src/integration-test/Dockerfile
@@ -1,9 +1,17 @@
 ### build the app
-
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+
 RUN mkdir -p /src
 WORKDIR /src
  
+### Optional: Set Proxy Variables
+# ENV http_proxy {value}
+# ENV https_proxy {value}
+# ENV HTTP_PROXY {value}
+# ENV HTTPS_PROXY {value}
+# ENV no_proxy {value}
+# ENV NO_PROXY {value}
+
 COPY . /src
 
 RUN dotnet restore && \
@@ -12,7 +20,6 @@ RUN dotnet restore && \
 ###########################################################
 
 ### build the runtime container
-
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
 
 # create a user
@@ -26,6 +33,3 @@ WORKDIR /app
 COPY --from=build /app .
 
 ENTRYPOINT [ "dotnet",  "integration-test.dll" ]
-
-# default to localhost
-CMD [ "-h","http://localhost:4120" ]


### PR DESCRIPTION
Ready to review and approve

- merged 4-co/helium-csharp:master into branch
  - github shows 1 commit behind but nothing changed
  - likely the PR from bluebell into 4-co
- moved middleware to /src/middleware so it can be shared with integration test
- added reference to helium.csproj
- added static value for robots content
- updated dockerfiles
  - added proxy comments to all dockerfiles
  - added spacing
  - removed default command line params from integration-test dockerfile