### PR TITLE
Smoke Test - added -d arg (duration in seconds)

### DIFF
--- a/src/integration-test/Program.cs
+++ b/src/integration-test/Program.cs
@@ -156,6 +156,11 @@ namespace HeliumIntegrationTest
                 _config.Threads = 10;
             }
 
+            if (_config.Duration < 0)
+            {
+                _config.Duration = 0;
+            }
+
             // add default files
             if (_config.FileList.Count == 0)
             {
@@ -261,6 +266,22 @@ namespace HeliumIntegrationTest
                         else if (args[i] == "-t")
                         {
                             if (int.TryParse(args[i + 1], out _config.Threads))
+                            {
+                                i++;
+                            }
+                            else
+                            {
+                                // exit on error
+                                Console.WriteLine(_threadsParameterError, args[i + 1]);
+                                Usage();
+                                Environment.Exit(-1);
+                            }
+                        }
+
+                        // handle duration (-d config.Duration (seconds))
+                        else if (args[i] == "-d")
+                        {
+                            if (int.TryParse(args[i + 1], out _config.Duration))
                             {
                                 i++;
                             }
@@ -396,6 +417,7 @@ namespace HeliumIntegrationTest
             Console.WriteLine("\tLoop Mode Parameters");
             Console.WriteLine("\t\t-s number of milliseconds to sleep between requests");
             Console.WriteLine("\t\t-t number of concurrent threads (max 10)");
+            Console.WriteLine("\t\t-d duration in seconds");
             Console.WriteLine("\t\t-w run as web server (listens on port 4122)");
             Console.WriteLine("\t\t-r randomize requests");
         }

--- a/src/integration-test/Smoker/SmokeTest.cs
+++ b/src/integration-test/Smoker/SmokeTest.cs
@@ -164,6 +164,7 @@ namespace Smoker
         public async Task RunLoop(int id, HeliumIntegrationTest.Config config, CancellationToken ct)
         {
             DateTime dt = DateTime.Now;
+            DateTime dtMax = DateTime.MaxValue;
             HttpRequestMessage req;
             string body;
             string res;
@@ -173,16 +174,19 @@ namespace Smoker
 
             Random rand = new Random(DateTime.Now.Millisecond);
 
+            // only run for duration (seconds)
+            if (config.Duration > 0)
+            {
+                dtMax = DateTime.Now.AddSeconds(config.Duration);
+            }
+
             if (ct.IsCancellationRequested)
             {
                 return;
             }
 
-            // send the first request as a warm up
-            await Warmup(_requestList[0].Url);
-
-            // loop forever
-            while (true)
+            // loop for duration or forever
+            while (DateTime.Now < dtMax)
             {
                 i = 0;
 

--- a/src/integration-test/config.cs
+++ b/src/integration-test/config.cs
@@ -8,6 +8,7 @@ namespace HeliumIntegrationTest
         public bool Random = false;
         public int SleepMs = 0;
         public int Threads = 0;
+        public int Duration = 0;
         public bool RunLoop = false;
         public bool RunWeb = false;
         public string Host = "http://localhost:4120";


### PR DESCRIPTION
- Added -d duration in seconds to smoke test
- Run for 10 seconds
  - dotnet run -- -h bluebell -i all.json -t 1 -s 100 -v -d 10

##Note that this only works if you are in RunLoop - i.e. specify -t and -s - does not work with -w
